### PR TITLE
Fix damage area for GPU demo

### DIFF
--- a/DemoApp/app/src/main/java/dev/chromeos/lowlatencystylusdemo/gpu/InkGLSurfaceScissor.java
+++ b/DemoApp/app/src/main/java/dev/chromeos/lowlatencystylusdemo/gpu/InkGLSurfaceScissor.java
@@ -53,6 +53,15 @@ public class InkGLSurfaceScissor {
     }
 
     /**
+     * Extend the current damage area to include the given Rect.
+     */
+    public void addRect(Rect rectToAdd) {
+        if (!rectToAdd.isEmpty()) {
+            mScissorBox.union(rectToAdd);
+        }
+    }
+
+    /**
      * Return the damage rectangle for use as a glScissor.
      *
      * @return Rect of damage area with a slightly larger "border" to guarantee correctness

--- a/DemoApp/app/src/main/java/dev/chromeos/lowlatencystylusdemo/gpu/LowLatencyStylusActivityGpu.java
+++ b/DemoApp/app/src/main/java/dev/chromeos/lowlatencystylusdemo/gpu/LowLatencyStylusActivityGpu.java
@@ -40,7 +40,7 @@ public class LowLatencyStylusActivityGpu extends AppCompatActivity {
     private final ImageButton[] brushButtons = new ImageButton[NUM_BRUSHES];
 
     // The main drawing canvas
-    private SampleLowLatencyInkGLSurfaceView mGLInkSurfaceView;
+    private SampleGLInkSurfaceView mGLInkSurfaceView;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -55,7 +55,7 @@ public class LowLatencyStylusActivityGpu extends AppCompatActivity {
         if (ab != null) ab.setDisplayHomeAsUpEnabled(true);
 
         // Create a low latency GLSurfaceView and add it to the main canvas
-        mGLInkSurfaceView = new SampleLowLatencyInkGLSurfaceView(this);
+        mGLInkSurfaceView = new SampleGLInkSurfaceView(this);
         mainCanvas.addView(mGLInkSurfaceView);
 
         // Set up buttons
@@ -118,7 +118,7 @@ public class LowLatencyStylusActivityGpu extends AppCompatActivity {
     private void selectBrush(int selectedBrush) {
         switch (selectedBrush) {
             case BRUSH_RED:
-                mGLInkSurfaceView.mBrushColor = SampleLowLatencyInkGLSurfaceView.INK_COLOR_RED;
+                mGLInkSurfaceView.mBrushColor = SampleGLInkSurfaceView.INK_COLOR_RED;
                 brushButtons[BRUSH_BLACK].setBackgroundColor(Color.TRANSPARENT);
                 brushButtons[BRUSH_RED].setBackground(ContextCompat.getDrawable(
                         this, R.drawable.selected_circle));
@@ -127,7 +127,7 @@ public class LowLatencyStylusActivityGpu extends AppCompatActivity {
                 break;
 
             case BRUSH_GREEN:
-                mGLInkSurfaceView.mBrushColor = SampleLowLatencyInkGLSurfaceView.INK_COLOR_GREEN;
+                mGLInkSurfaceView.mBrushColor = SampleGLInkSurfaceView.INK_COLOR_GREEN;
                 brushButtons[BRUSH_BLACK].setBackgroundColor(Color.TRANSPARENT);
                 brushButtons[BRUSH_RED].setBackgroundColor(Color.TRANSPARENT);
                 brushButtons[BRUSH_GREEN].setBackground(ContextCompat.getDrawable(
@@ -136,7 +136,7 @@ public class LowLatencyStylusActivityGpu extends AppCompatActivity {
                 break;
 
             case BRUSH_BLUE:
-                mGLInkSurfaceView.mBrushColor = SampleLowLatencyInkGLSurfaceView.INK_COLOR_BLUE;
+                mGLInkSurfaceView.mBrushColor = SampleGLInkSurfaceView.INK_COLOR_BLUE;
                 brushButtons[BRUSH_BLACK].setBackgroundColor(Color.TRANSPARENT);
                 brushButtons[BRUSH_RED].setBackgroundColor(Color.TRANSPARENT);
                 brushButtons[BRUSH_GREEN].setBackgroundColor(Color.TRANSPARENT);
@@ -146,7 +146,7 @@ public class LowLatencyStylusActivityGpu extends AppCompatActivity {
 
             case BRUSH_BLACK:
             default:
-                mGLInkSurfaceView.mBrushColor = SampleLowLatencyInkGLSurfaceView.INK_COLOR_BLACK;
+                mGLInkSurfaceView.mBrushColor = SampleGLInkSurfaceView.INK_COLOR_BLACK;
                 brushButtons[BRUSH_BLACK].setBackground(ContextCompat.getDrawable(
                         this, R.drawable.selected_circle));
                 brushButtons[BRUSH_RED].setBackgroundColor(Color.TRANSPARENT);

--- a/DemoApp/app/src/main/java/dev/chromeos/lowlatencystylusdemo/gpu/gpu_compare/LowLatencyStylusActivityGpuCompare.java
+++ b/DemoApp/app/src/main/java/dev/chromeos/lowlatencystylusdemo/gpu/gpu_compare/LowLatencyStylusActivityGpuCompare.java
@@ -31,7 +31,7 @@ import androidx.core.content.ContextCompat;
 import com.google.android.material.slider.Slider;
 
 import dev.chromeos.lowlatencystylusdemo.R;
-import dev.chromeos.lowlatencystylusdemo.gpu.SampleLowLatencyInkGLSurfaceView;
+import dev.chromeos.lowlatencystylusdemo.gpu.SampleGLInkSurfaceView;
 
 public class LowLatencyStylusActivityGpuCompare extends AppCompatActivity {
     // Brush buttons
@@ -41,7 +41,7 @@ public class LowLatencyStylusActivityGpuCompare extends AppCompatActivity {
 
     // The drawing canvases
     private RegularCanvasSurfaceView mRegularCanvasSurfaceView;
-    private SampleLowLatencyInkGLSurfaceView mGLInkSurfaceView;
+    private SampleGLInkSurfaceView mGLInkSurfaceView;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -61,7 +61,7 @@ public class LowLatencyStylusActivityGpuCompare extends AppCompatActivity {
         regularCanvas.addView(mRegularCanvasSurfaceView);
 
         // Create a low latency GLSurfaceView and add it
-        mGLInkSurfaceView = new SampleLowLatencyInkGLSurfaceView(this);
+        mGLInkSurfaceView = new SampleGLInkSurfaceView(this);
         lowLatencyCanvas.addView(mGLInkSurfaceView);
 
         // Set up buttons
@@ -125,8 +125,8 @@ public class LowLatencyStylusActivityGpuCompare extends AppCompatActivity {
     private void selectBrush(int selectedBrush) {
         switch (selectedBrush) {
             case BRUSH_RED:
-                mGLInkSurfaceView.mBrushColor = SampleLowLatencyInkGLSurfaceView.INK_COLOR_RED;
-                mRegularCanvasSurfaceView.inkStrokeColor = SampleLowLatencyInkGLSurfaceView.INK_COLOR_RED;
+                mGLInkSurfaceView.mBrushColor = SampleGLInkSurfaceView.INK_COLOR_RED;
+                mRegularCanvasSurfaceView.inkStrokeColor = SampleGLInkSurfaceView.INK_COLOR_RED;
                 brushButtons[BRUSH_BLACK].setBackgroundColor(Color.TRANSPARENT);
                 brushButtons[BRUSH_RED].setBackground(ContextCompat.getDrawable(
                         this, R.drawable.selected_circle));
@@ -135,8 +135,8 @@ public class LowLatencyStylusActivityGpuCompare extends AppCompatActivity {
                 break;
 
             case BRUSH_GREEN:
-                mGLInkSurfaceView.mBrushColor = SampleLowLatencyInkGLSurfaceView.INK_COLOR_GREEN;
-                mRegularCanvasSurfaceView.inkStrokeColor = SampleLowLatencyInkGLSurfaceView.INK_COLOR_GREEN;
+                mGLInkSurfaceView.mBrushColor = SampleGLInkSurfaceView.INK_COLOR_GREEN;
+                mRegularCanvasSurfaceView.inkStrokeColor = SampleGLInkSurfaceView.INK_COLOR_GREEN;
                 brushButtons[BRUSH_BLACK].setBackgroundColor(Color.TRANSPARENT);
                 brushButtons[BRUSH_RED].setBackgroundColor(Color.TRANSPARENT);
                 brushButtons[BRUSH_GREEN].setBackground(ContextCompat.getDrawable(
@@ -145,8 +145,8 @@ public class LowLatencyStylusActivityGpuCompare extends AppCompatActivity {
                 break;
 
             case BRUSH_BLUE:
-                mGLInkSurfaceView.mBrushColor = SampleLowLatencyInkGLSurfaceView.INK_COLOR_BLUE;
-                mRegularCanvasSurfaceView.inkStrokeColor = SampleLowLatencyInkGLSurfaceView.INK_COLOR_BLUE;
+                mGLInkSurfaceView.mBrushColor = SampleGLInkSurfaceView.INK_COLOR_BLUE;
+                mRegularCanvasSurfaceView.inkStrokeColor = SampleGLInkSurfaceView.INK_COLOR_BLUE;
                 brushButtons[BRUSH_BLACK].setBackgroundColor(Color.TRANSPARENT);
                 brushButtons[BRUSH_RED].setBackgroundColor(Color.TRANSPARENT);
                 brushButtons[BRUSH_GREEN].setBackgroundColor(Color.TRANSPARENT);
@@ -156,8 +156,8 @@ public class LowLatencyStylusActivityGpuCompare extends AppCompatActivity {
 
             case BRUSH_BLACK:
             default:
-                mGLInkSurfaceView.mBrushColor = SampleLowLatencyInkGLSurfaceView.INK_COLOR_BLACK;
-                mRegularCanvasSurfaceView.inkStrokeColor = SampleLowLatencyInkGLSurfaceView.INK_COLOR_BLACK;
+                mGLInkSurfaceView.mBrushColor = SampleGLInkSurfaceView.INK_COLOR_BLACK;
+                mRegularCanvasSurfaceView.inkStrokeColor = SampleGLInkSurfaceView.INK_COLOR_BLACK;
                 brushButtons[BRUSH_BLACK].setBackground(ContextCompat.getDrawable(
                         this, R.drawable.selected_circle));
                 brushButtons[BRUSH_RED].setBackgroundColor(Color.TRANSPARENT);

--- a/DemoApp/app/src/main/java/dev/chromeos/lowlatencystylusdemo/gpu/gpu_compare/RegularCanvasSurfaceView.java
+++ b/DemoApp/app/src/main/java/dev/chromeos/lowlatencystylusdemo/gpu/gpu_compare/RegularCanvasSurfaceView.java
@@ -16,7 +16,7 @@
 
 package dev.chromeos.lowlatencystylusdemo.gpu.gpu_compare;
 
-import static dev.chromeos.lowlatencystylusdemo.gpu.SampleLowLatencyInkGLSurfaceView.INK_COLOR_BLACK;
+import static dev.chromeos.lowlatencystylusdemo.gpu.SampleGLInkSurfaceView.INK_COLOR_BLACK;
 
 import android.content.Context;
 import android.graphics.PointF;


### PR DESCRIPTION
The GPU demo was not correctly maintaining the previous prediction
damage area, leading to leftover prediction strokes.

Also renamed SampleGLInkSurfaceView class to match library name.