### PR TITLE
Added a speed-up for duplicated touch events

### DIFF
--- a/DemoApp/.idea/misc.xml
+++ b/DemoApp/.idea/misc.xml
@@ -3,6 +3,7 @@
   <component name="DesignSurface">
     <option name="filePathToZoomLevelMap">
       <map>
+        <entry key="app/src/main/res/drawable-v24/ic_launcher_foreground.xml" value="0.38645833333333335" />
         <entry key="app/src/main/res/drawable/box_border.xml" value="0.30625" />
         <entry key="app/src/main/res/drawable/brush_not_selected.xml" value="0.22083333333333333" />
         <entry key="app/src/main/res/drawable/brush_selected.xml" value="0.3859375" />

--- a/DemoApp/app/src/main/res/layout/compare.xml
+++ b/DemoApp/app/src/main/res/layout/compare.xml
@@ -33,7 +33,7 @@
         app:layout_constraintBottom_toTopOf="@id/button_bar"
         app:layout_constraintEnd_toStartOf="@+id/guideline_middle"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"/>
+        app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
         android:id="@+id/text_regular_canvas"

--- a/DemoApp/app/src/main/res/values/colors.xml
+++ b/DemoApp/app/src/main/res/values/colors.xml
@@ -21,5 +21,5 @@
     <color name="purple700">#3700B3</color>
     <color name="teal200">#03DAC5</color>
     <color name="table">#E3C5AC</color>
-    <color name="paper">#FFF1F1F1</color>
+    <color name="paper">#FFFFFFFF</color>
 </resources>


### PR DESCRIPTION
Some devices and styli especially can generate multiple draw/touch
events very close to each other. This tries to de-dupe close points.